### PR TITLE
Add AWS CDK deployment workflow

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -1,0 +1,26 @@
+name: deploy-lambda
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Deploy DiscordBotLambdaStack
+        run: npx cdk deploy --require-approval never

--- a/README.md
+++ b/README.md
@@ -95,3 +95,20 @@ source activate_venv.sh
 # install all dependencies
 pip install -r requirements.txt
 ```
+
+### AWS Deployment
+
+A GitHub Actions workflow automatically deploys the `DiscordBotLambdaStack` when changes are pushed to the `main` branch. The workflow is defined in `.github/workflows/deploy-lambda.yml` and performs the following steps:
+
+1. Checks out the repository and sets up Node.js.
+2. Installs Node dependencies with `npm ci`.
+3. Configures AWS credentials using `aws-actions/configure-aws-credentials@v4`.
+4. Runs `npx cdk deploy --require-approval never` to deploy the stack.
+
+Create these repository secrets so the workflow can authenticate with AWS:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION`
+
+The Lambda code relies on environment variables stored in `.env`. Refer to `.env.example` for the variables that must be provided.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for automatic AWS CDK deployments
- document AWS deployment secrets in the README

## Testing
- `pytest -q`
- `npm ci`
- `npm test`
- `pylint $(git ls-files '*.py') --errors-only`

------
https://chatgpt.com/codex/tasks/task_e_684135a1ec4c8327a6be46ecead47053